### PR TITLE
Add ability to pass options

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,12 +1,17 @@
 'use strict';
 
+var loaderUtils = require('loader-utils');
+var _ = require('lodash');
 var isparta = require('isparta');
 
 module.exports = function(source) {
-    var instrumenter = new isparta.Instrumenter({
+
+    var query = loaderUtils.parseQuery(this.query);
+    var options = _.assign({
         embedSource: true,
         noAutoWrap: true
-    });
+    }, query);
+    var instrumenter = new isparta.Instrumenter(options);
 
     if (this.cacheable) {
         this.cacheable();

--- a/package.json
+++ b/package.json
@@ -34,5 +34,9 @@
   "engines": {
     "node": ">=0.10.0"
   },
-  "license": "WTFPL"
+  "license": "WTFPL",
+  "dependencies": {
+    "loader-utils": "^0.2.6",
+    "lodash": "^3.5.0"
+  }
 }


### PR DESCRIPTION
So you can pass options (such as babel specific options) to loader query. Eg: `isparta-instrumenter-loader?{babel:{experimental:true}}`
